### PR TITLE
BUG responsável nulo ao tentar editar Evento

### DIFF
--- a/application/models/Evento.php
+++ b/application/models/Evento.php
@@ -299,12 +299,10 @@ class Application_Model_Evento extends Zend_Db_Table_Abstract {
      */
     public function temPermissao($id_evento, $responsavel) {
         $sql = "
-            SELECT EXIST(
-                SELECT *
-                FROM evento e
-                WHERE id_evento = ? AND responsavel = ?
-            )";
-        return $this->getAdapter()->fetchOne($sql, array($id_evento, $responsavel));
+            SELECT responsavel
+            FROM evento
+            WHERE id_evento = ? AND responsavel = ?";
+        return $this->getAdapter()->fetchOne($sql, array($id_evento, $responsavel)) != null;
     }
 
     public function getResponsavel($id_evento) {

--- a/application/views/scripts/evento/salvar.phtml
+++ b/application/views/scripts/evento/salvar.phtml
@@ -15,7 +15,7 @@ $form = $this->form;
 ?>
 
 <form method="<?php echo $form->getMethod() ?>"
-    action="<?php echo $form->getAction()?>">
+    action="<?php echo $form->getAction() ?>">
 
 <div class="row">
     <div class="col-md-6">
@@ -99,7 +99,8 @@ $form = $this->form;
 
 <div class="row">
     <div class="col-md-6">
-        <a href="<?php echo $this->url(array(), 'submissao', true)?>" class="btn btn-default">
+        <a href="<?php echo $this->url(array(), 'submissao', true) ?>"
+            class="btn btn-default">
             <?php echo $this->translate("Cancel"); ?>
         </a>
         <?php echo $form->submit->renderViewHelper() ?>


### PR DESCRIPTION
responsável removida da query de update, pois é uma valor que
não deve mais mudar.

Antes de atualizar é verificado se o usuário que está tentando editar
o evento é o responsável ou admin. Caso contrário o usuário
é informado que não poderá editar o evento.

Fixed #61.